### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,16 +173,15 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.11.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c0994e656bba7b922d8dd1245db90672ffb701e684e45be58f20719d69abc5a"
+checksum = "a50aab2529019abfabfa93f1e6c41ef392f91fbf179b347a7e96abb524884a08"
 dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
  "regex",
  "terminal_size",
- "termios",
  "unicode-width",
  "winapi 0.3.9",
  "winapi-util",
@@ -205,13 +204,14 @@ dependencies = [
 
 [[package]]
 name = "dialoguer"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4aa86af7b19b40ef9cbef761ed411a49f0afa06b7b6dcd3dfe2f96a3c546138"
+checksum = "70f807b2943dc90f9747497d9d65d7e92472149be0b88bf4ce1201b4ac979c26"
 dependencies = [
  "console",
  "lazy_static",
  "tempfile",
+ "zeroize",
 ]
 
 [[package]]
@@ -692,9 +692,9 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "mc-legacy-formatting"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92f9f4474324485ae9d641b79b1115769e47e367b24af3f3498bfe52a6180750"
+checksum = "708af36424d1f26477eff5e56e5531dbd9ea93ff47075539adaf339fb4aca1ab"
 dependencies = [
  "bitflags",
  "colored",
@@ -1296,15 +1296,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termios"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1800,3 +1791,9 @@ dependencies = [
  "winapi 0.2.8",
  "winapi-build",
 ]
+
+[[package]]
+name = "zeroize"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45af6a010d13e4cf5b54c94ba5a2b2eba5596b9e46bf5875612d332a1f2b3f86"

--- a/mcping/Cargo.toml
+++ b/mcping/Cargo.toml
@@ -18,5 +18,5 @@ thiserror = "1.0"
 trust-dns-resolver = "0.19"
 
 [dev-dependencies]
-dialoguer = "0.6"
-mc-legacy-formatting = "0.1"
+dialoguer = "0.7"
+mc-legacy-formatting = "0.2"

--- a/mcping/examples/cli.rs
+++ b/mcping/examples/cli.rs
@@ -1,5 +1,5 @@
 use dialoguer::Input;
-use mc_legacy_formatting::{PrintSpanColored, SpanIter};
+use mc_legacy_formatting::SpanExt;
 
 fn main() -> Result<(), mcping::Error> {
     let server_address = Input::<String>::new()
@@ -9,14 +9,20 @@ fn main() -> Result<(), mcping::Error> {
     let (latency, status) = mcping::get_status(&server_address)?;
 
     print!("version: ");
-    SpanIter::new(&status.version.name)
-        .map(PrintSpanColored::from)
+    status
+        .version
+        .name
+        .span_iter()
+        .map(|s| s.wrap_colored())
         .for_each(|s| print!("{}", s));
 
     println!();
     println!("description:");
-    SpanIter::new(&status.description.text())
-        .map(PrintSpanColored::from)
+    status
+        .description
+        .text()
+        .span_iter()
+        .map(|s| s.wrap_colored())
         .for_each(|s| print!("{}", s));
 
     println!();
@@ -35,9 +41,11 @@ fn main() -> Result<(), mcping::Error> {
             println!();
 
             for player in sample {
-                SpanIter::new(&player.name)
-                    .map(PrintSpanColored::from)
-                    .for_each(|s| print!("  {}", s));
+                player
+                    .name
+                    .span_iter()
+                    .map(|s| s.wrap_colored())
+                    .for_each(|s| print!("{}", s));
                 println!();
             }
         })


### PR DESCRIPTION
Updates `dialoguer` and `mc-legacy-formatting`. Makes use of `mc-legacy-formatting`'s new `SpanExt` trait.