### PR TITLE
Allow for passing a timeout into `get_status`

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -7,6 +7,8 @@ on:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
   pull_request:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
 
 jobs:
   audit:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
-          override: true
       - uses: actions-rs/cargo@v1
         with:
           command: check
@@ -26,7 +25,6 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
-          override: true
       - uses: actions-rs/cargo@v1
         with:
           command: test
@@ -40,9 +38,23 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
-          override: true
           components: rustfmt
       - uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: clippy
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings

--- a/discord/src/main.rs
+++ b/discord/src/main.rs
@@ -10,14 +10,13 @@ use serenity::{
 use std::{fs::File, io::prelude::*, time::Duration};
 
 fn main() -> Result<(), anyhow::Error> {
-    let cfg = load_config().with_context(|| format!("failed to load config"))?;
-    let handler = Handler::new(cfg.address, cfg.command)
-        .with_context(|| format!("failed to create handler"))?;
-    let mut client = Client::new(&cfg.token, handler)
-        .with_context(|| format!("failed to create Discord client"))?;
+    let cfg = load_config().with_context(|| "failed to load config")?;
+    let handler = Handler::new(cfg.address, cfg.command);
+    let mut client =
+        Client::new(&cfg.token, handler).with_context(|| "failed to create Discord client")?;
     client
         .start()
-        .with_context(|| format!("failed to start Discord client"))?;
+        .with_context(|| "failed to start Discord client")?;
 
     Ok(())
 }
@@ -49,14 +48,14 @@ struct Handler {
 }
 
 impl Handler {
-    fn new<S>(addr: S, command: String) -> Result<Self, anyhow::Error>
+    fn new<S>(addr: S, command: String) -> Self
     where
         S: Into<String>,
     {
-        Ok(Handler {
+        Handler {
             addr: addr.into(),
             command,
-        })
+        }
     }
 }
 
@@ -75,7 +74,7 @@ impl EventHandler for Handler {
         let chan = msg.channel_id;
 
         // Retrieve our response, decode the icon, and build our sample.
-        let res = mcping::get_status(&self.addr, Duration::from_secs(10)).and_then(|(ping, r)| {
+        let res = mcping::get_status(&self.addr, Duration::from_secs(10)).map(|(ping, r)| {
             // The icon is a base64 encoded PNG so we must decode that first.
             let icon = r
                 .favicon
@@ -106,16 +105,16 @@ impl EventHandler for Handler {
                 .players
                 .sample
                 .map(|s| s.into_iter().map(|p| sanitize(&p.name)).join(", "))
-                .unwrap_or("None".to_string());
+                .unwrap_or_else(|| "None".to_string());
 
-            Ok((
+            (
                 icon,
                 r.description,
                 r.players.online,
                 r.players.max,
                 sample,
                 ping,
-            ))
+            )
         });
 
         // Attempt to send a message to this channel.

--- a/discord/src/main.rs
+++ b/discord/src/main.rs
@@ -7,7 +7,7 @@ use serenity::{
     model::channel::Message,
     prelude::EventHandler,
 };
-use std::{fs::File, io::prelude::*};
+use std::{fs::File, io::prelude::*, time::Duration};
 
 fn main() -> Result<(), anyhow::Error> {
     let cfg = load_config().with_context(|| format!("failed to load config"))?;
@@ -75,7 +75,7 @@ impl EventHandler for Handler {
         let chan = msg.channel_id;
 
         // Retrieve our response, decode the icon, and build our sample.
-        let res = mcping::get_status(&self.addr).and_then(|(ping, r)| {
+        let res = mcping::get_status(&self.addr, Duration::from_secs(10)).and_then(|(ping, r)| {
             // The icon is a base64 encoded PNG so we must decode that first.
             let icon = r
                 .favicon

--- a/mcping/examples/cli.rs
+++ b/mcping/examples/cli.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use dialoguer::Input;
 use mc_legacy_formatting::SpanExt;
 
@@ -6,7 +8,7 @@ fn main() -> Result<(), mcping::Error> {
         .with_prompt("Minecraft server address")
         .interact()?;
 
-    let (latency, status) = mcping::get_status(&server_address)?;
+    let (latency, status) = mcping::get_status(&server_address, Duration::from_secs(10))?;
 
     print!("version: ");
     status

--- a/mcping/src/lib.rs
+++ b/mcping/src/lib.rs
@@ -32,7 +32,7 @@ trait ReadMinecraftExt: Read + ReadBytesExt {
         let mut res = 0i32;
         for i in 0..5 {
             let part = self.read_u8()?;
-            res |= (part as i32 & 0x7F) << 7 * i;
+            res |= (part as i32 & 0x7F) << (7 * i);
             if part & 0x80 == 0 {
                 return Ok(res);
             }


### PR DESCRIPTION
As it is currently, there's no way to provide a timeout when calling `get_status`. If you try giving the CLI example an address like `google.com`, you'll note that it sits there trying to open the TCP connection until the OS times it out (about a minute on my machine).

That's way too long for my app, and probably for most people; this PR adds the ability to optionally pass a timeout duration to `get_status` that `Connection::new` can use.